### PR TITLE
Add unit test for hash strategy

### DIFF
--- a/packages/common/src/location/hash_location_strategy.ts
+++ b/packages/common/src/location/hash_location_strategy.ts
@@ -61,17 +61,14 @@ export class HashLocationStrategy extends LocationStrategy {
 
   prepareExternalUrl(internal: string): string {
     const url = joinWithSlash(this._baseHref, internal);
-    // equivalnt to location.origin + location.pathname
-    const baseUrl = this._platformLocation.protocol + '//' + this._platformLocation.hostname +
-        (!!this._platformLocation.port ? ':' + this._platformLocation.port : '') +
-        this._platformLocation.pathname + this._platformLocation.search;
+
+    const baseUrl = this._platformLocation.pathname + this._platformLocation.search;
 
     return url.length > 0 ? baseUrl + '#' + url : baseUrl;
   }
 
   pushState(state: any, title: string, path: string, queryParams: string) {
     let url = this.prepareExternalUrl(path + normalizeQueryParams(queryParams));
-
     this._platformLocation.pushState(state, title, url);
   }
 

--- a/packages/common/src/location/platform_location.ts
+++ b/packages/common/src/location/platform_location.ts
@@ -139,7 +139,7 @@ export class BrowserPlatformLocation extends PlatformLocation {
     if (supportsState()) {
       this._history.pushState(state, title, url);
     } else {
-      this.location.assign(url);
+      this.location.hash = url;
     }
   }
 
@@ -147,7 +147,7 @@ export class BrowserPlatformLocation extends PlatformLocation {
     if (supportsState()) {
       this._history.replaceState(state, title, url);
     } else {
-      this.location.replace(url);
+      this.location.hash = url;
     }
   }
 

--- a/packages/common/test/location/location_spec.ts
+++ b/packages/common/test/location/location_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {CommonModule, Location, LocationStrategy, PathLocationStrategy, PlatformLocation} from '@angular/common';
+import {HashLocationStrategy} from '@angular/common/src/common';
 import {MockPlatformLocation} from '@angular/common/testing';
 import {TestBed, inject} from '@angular/core/testing';
 
@@ -73,6 +74,38 @@ describe('Location Class', () => {
          location.back();
 
          expect(location.getState()).toEqual({url: 'test1'});
+       }));
+
+  });
+
+  describe('location.go() using hash location strategy', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [CommonModule],
+        providers: [
+          {provide: LocationStrategy, useClass: HashLocationStrategy},
+          {
+            provide: PlatformLocation,
+            useFactory: () => {
+              return new MockPlatformLocation(
+                  {startUrl: 'http://foo.com/original/path?param=true'});
+            }
+          },
+          {provide: Location, useClass: Location, deps: [LocationStrategy, PlatformLocation]},
+        ]
+      });
+    });
+
+    it('shoud keep the original url',
+       inject([Location, PlatformLocation], (location: Location, platform: PlatformLocation) => {
+
+         expect(platform.pathname).toEqual('/original/path');
+         expect(platform.search).toEqual('?param=true');
+
+         location.go('/test', '', {});
+
+         expect(platform.pathname).toEqual('/original/path');
+         expect(platform.search).toEqual('?param=true');
        }));
 
   });


### PR DESCRIPTION
Reverted changes related to host, port and protocol because they seem not to affect the strategy behavior.
